### PR TITLE
Add CI workflow for docs

### DIFF
--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -1,0 +1,23 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Generate documentation
+        run: |
+          python3 generate_documentation.py
+          mkdir -p docs
+          mv workflow-documentation.html docs/index.html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Then open `workflow-documentation.html` in your browser for:
 - 📄 **JSON Viewer** - Examine raw workflow files with copy/download
 - 🏷️ **Intelligent Tagging** - Automatic trigger type and complexity detection
 
+You can also view the documentation online at
+[https://your-username.github.io/n8n-workflows-library/](https://your-username.github.io/n8n-workflows-library/),
+automatically published from the `gh-pages` branch.
+
 ### Features
 
 The documentation system automatically analyzes each workflow to extract:


### PR DESCRIPTION
## Summary
- publish generated documentation to `gh-pages` on every push to `main`
- mention the public documentation URL in README

## Testing
- `python3 generate_documentation.py`

------
https://chatgpt.com/codex/tasks/task_e_684d91eaf58c832ab130b8b2706ba365