### PR TITLE
Add blank line after main call

### DIFF
--- a/generate_documentation.py
+++ b/generate_documentation.py
@@ -1441,3 +1441,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add a trailing blank line after calling `main()`

## Testing
- `python3 generate_documentation.py`

------
https://chatgpt.com/codex/tasks/task_e_684d91f4277c832abf686b60c4778746